### PR TITLE
Added extension-key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,10 @@
   },
   "replace": {
     "xima-media/xm_formcycle": "self.version"
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "xm_formcycle"
+    }
   }
 }


### PR DESCRIPTION
Since version 3.1.0 of `typo3/cms-composer-installers` the `extension-key` is required in `composer.json`:
https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html

Fixes #3