### PR TITLE
fix: extend csp font-src for formcycle url

### DIFF
--- a/Classes/ContentSecurityPolicy/EventListener/FrontendListener.php
+++ b/Classes/ContentSecurityPolicy/EventListener/FrontendListener.php
@@ -30,5 +30,10 @@ final class FrontendListener
             Directive::FrameSrc,
             new UriValue($formcycleUrl),
         );
+
+        $event->getCurrentPolicy()->extend(
+            Directive::FontSrc,
+            new UriValue($formcycleUrl),
+        );
     }
 }


### PR DESCRIPTION
Depending on the configured form style, font faces are  included not only base64 encoded but relative to the formcycle url. This PR extends the FontSrc directive to add the configured url as well.