### PR TITLE
feat: add language parameter to formcycle url

### DIFF
--- a/Classes/Dto/ElementSettings.php
+++ b/Classes/Dto/ElementSettings.php
@@ -21,6 +21,8 @@ class ElementSettings
 
     public string $additionalParameters = '';
 
+    public string $language = '';
+
     public static function createFromContentElement(
         FlexFormService $flexFormService,
         ContentObjectRenderer $cObj,
@@ -29,6 +31,9 @@ class ElementSettings
 
         $settings = new self();
         $settings->formId = $cObj->data['tx_xmformcycle_form_id'] ?? '';
+
+        $language = $cObj->getRequest()?->getAttribute('language')?->getTwoLetterIsoCode() ?? '';
+        $settings->language = $language;
 
         $settings->successPid = $xml['settings']['xf']['siteok'] ?? 0;
         $settings->errorPid = $xml['settings']['xf']['siteerror'] ?? 0;

--- a/Classes/Dto/ElementSettings.php
+++ b/Classes/Dto/ElementSettings.php
@@ -32,7 +32,7 @@ class ElementSettings
         $settings = new self();
         $settings->formId = $cObj->data['tx_xmformcycle_form_id'] ?? '';
 
-        $language = $cObj->getRequest()?->getAttribute('language')?->getTwoLetterIsoCode() ?? '';
+        $language = $cObj->getRequest()->getAttribute('language')->getTwoLetterIsoCode();
         $settings->language = $language;
 
         $settings->successPid = $xml['settings']['xf']['siteok'] ?? 0;

--- a/Classes/Service/FormcycleService.php
+++ b/Classes/Service/FormcycleService.php
@@ -147,6 +147,7 @@ final class FormcycleService
             'xfc-pp-base-url' => '',
             'xfc-pp-use-base-url' => false,
             'xfc-rp-keepalive' => true,
+            'lang' => $settings->language ?: 'de',
         ];
 
         if ($settings->successPid) {


### PR DESCRIPTION
Get language code from current request and add it to the common formcycle url params. Use `de` as fallback.

resolves #29 