### PR TITLE
Disable cache in default and integrated mode

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -1,5 +1,5 @@
-tt_content.formcycle =< lib.contentElement
-tt_content.formcycle {
+temp.formcycle =< lib.contentElement
+temp.formcycle {
   templateRootPaths.1 = EXT:xm_formcycle/Resources/Private/Templates/
   templateRootPaths.2 = {$plugin.tx_xmformcycle.view.templateRootPath}
   partialRootPaths.1 = EXT:xm_formcycle/Resources/Private/Partials/
@@ -8,12 +8,53 @@ tt_content.formcycle {
   layoutRootPaths.2 = {$plugin.tx_xmformcycle.view.layoutRootPath}
 
   templateName = Formcycle
+}
 
-  dataProcessing {
+tt_content.formcycle = COA
+tt_content.formcycle {
+
+  10 = COA_INT
+  10.stdWrap.if.equals = default
+  10.stdWrap.if.value.data = flexform : pi_flexform:settings.xf.integrationMode
+  10.1 =< temp.formcycle
+  10.1.dataProcessing {
     1709129505 = formcycle-ajax
     1709129509 = formcycle-iframe
     1709129512 = formcycle-integrated
   }
+
+  20 = COA_INT
+  20.stdWrap.if.equals = integrated
+  20.stdWrap.if.value.data = flexform : pi_flexform:settings.xf.integrationMode
+  20.1 =< temp.formcycle
+  20.1.dataProcessing {
+    1709129512 = formcycle-integrated
+  }
+
+  30 = COA
+  30.stdWrap.if.equals = AJAX (TYPO3)
+  30.stdWrap.if.value.data = flexform : pi_flexform:settings.xf.integrationMode
+  30.1 =< temp.formcycle
+  30.1.dataProcessing {
+    1709129505 = formcycle-ajax
+  }
+
+  40 = COA
+  40.stdWrap.if.equals = AJAX (FORMCYCLE)
+  40.stdWrap.if.value.data = flexform : pi_flexform:settings.xf.integrationMode
+  40.1 =< temp.formcycle
+  40.1.dataProcessing {
+    1709129505 = formcycle-ajax
+  }
+
+  50 = COA
+  50.stdWrap.if.equals = iFrame
+  50.stdWrap.if.value.data = flexform : pi_flexform:settings.xf.integrationMode
+  50.1 =< temp.formcycle
+  50.1.dataProcessing {
+    1709129509 = formcycle-iframe
+  }
+
 }
 
 formcycle_ajax = PAGE


### PR DESCRIPTION
When submitting a formcycle forms, the formcycle application server requires a session id in the DOM that cannot be cached. When using the AJAX or iFrame mode, a new session id is always obtained. 

This PR renders the `default` and `integrated` mode as COA_INT. This prevents TYPO3 and the browser to cache critical values.