### PR TITLE
fix: extension configuration

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,8 +1,8 @@
-# cat=basic//100; type=string; label=Formcycle server URL, e.g. https://pro.formcloud.de/
+# cat=basic//100; type=string; label=Formcycle server URL
 formcycleUrl =
 
-# cat=basic//100; type=string; label=The client ID of your Formcycle installation
+# cat=basic//101; type=string; label=The client ID of your Formcycle installation
 formcycleClientId =
 
-# cat=basic//104; type=options[integrated, AJAX (TYPO3), AJAX (FORMCYCLE), iFrame]; label=Integration mode
+# cat=basic//104; type=options[integrated, AJAX (TYPO3), AJAX (FORMCYCLE), iFrame]; label=Default integration mode
 defaultIntegrationMode = integrated


### PR DESCRIPTION
This PR fixes errors in the `ext_conf_template.txt`, which led to missing config options in the TYPO3 `Settings` module.