### PR TITLE
feat: extend csp generation for style-src-elem directive

### DIFF
--- a/Classes/ContentSecurityPolicy/EventListener/FrontendListener.php
+++ b/Classes/ContentSecurityPolicy/EventListener/FrontendListener.php
@@ -32,6 +32,11 @@ final class FrontendListener
         );
 
         $event->getCurrentPolicy()->extend(
+            Directive::StyleSrcElem,
+            new UriValue($formcycleUrl),
+        );
+
+        $event->getCurrentPolicy()->extend(
             Directive::FontSrc,
             new UriValue($formcycleUrl),
         );


### PR DESCRIPTION
This PR adjusts the Content-Security-Policy to changes in formcycle 8.3.